### PR TITLE
Added a try/catch if the channel does not have a physical unit

### DIFF
--- a/mdfreader/mdf3reader.py
+++ b/mdfreader/mdf3reader.py
@@ -794,7 +794,10 @@ class mdf3(dict):
                             self.masterChannelList['master' + str(dataGroup)].append(channelName)
                             self[channelName] = {}
                             self[channelName]['master'] = 'master' + str(dataGroup)  # master channel of channel
-                            self[channelName]['unit'] = info['CCBlock'][dataGroup][channelGroup][channel]['physicalUnit']
+                            try:
+                                self[channelName]['unit'] = info['CCBlock'][dataGroup][channelGroup][channel]['physicalUnit']
+                            except: 
+                                self[channelName]['unit'] = None
                             self[channelName]['description'] = info['CNBlock'][dataGroup][channelGroup][channel]['signalDescription']
                             self[channelName]['data'] = L[channelName]
                             L.pop(channelName, None)  # free memory


### PR DESCRIPTION
mdfreader was failing on our MDF files. Not all of the channels we record have physical units assigned.

There is probably a better way to test for this than a ```try/except```. I also only changed md3reader since my files are all MDF3.