### PR TITLE
double-channel-mf3 deals with duplicate signalname in CNBlock for mdfinfo3

### DIFF
--- a/mdfreader/mdfinfo3.py
+++ b/mdfreader/mdfinfo3.py
@@ -147,6 +147,7 @@ class info3(dict):
                 # Get pointer to next first Channel block
                 CNpointer = self['CGBlock'][dataGroup][channelGroup]['pointerToFirstCNBlock']
 
+		snames = set()
                 # For each Channel
                 for channel in range(self['CGBlock'][dataGroup][channelGroup]['numberOfChannels']):
 
@@ -162,6 +163,7 @@ class info3(dict):
                     # Clean signal name
                     shortSignalName = self['CNBlock'][dataGroup][channelGroup][channel]['signalName']  # short name of signal
                     CNTXpointer = self['CNBlock'][dataGroup][channelGroup][channel]['pointerToASAMNameBlock']
+
                     if CNTXpointer > 0:
                         longSignalName = self.mdfblockread3(self.blockformats3('TXFormat'), fid, CNTXpointer)  # long name of signal
                         longSignalName = longSignalName['Text']
@@ -177,7 +179,13 @@ class info3(dict):
                     signalname = signalname[0]
                     if self.filterChannelNames:
                         signalname = signalname.split('.')[-1]  # filters channels modules
-                    self['CNBlock'][dataGroup][channelGroup][channel]['signalName'] = signalname
+
+		    if signalname in snames:
+			self['CNBlock'][dataGroup][channelGroup][channel]['signalName'] = signalname + '_' + str(channel)
+			print 'WARNING added number to duplicate channel name: ' + self['CNBlock'][dataGroup][channelGroup][channel]['signalName']
+		    else:
+			self['CNBlock'][dataGroup][channelGroup][channel]['signalName'] = signalname
+			snames.add(signalname)
                     #self.channelNameList.append( signalname )
 
                     # Read channel description
@@ -382,6 +390,7 @@ class info3(dict):
                 # Get pointer to next first Channel block
                 CNpointer = self['CGBlock'][dataGroup][channelGroup]['pointerToFirstCNBlock']
 
+		snames = set()
                 # For each Channel
                 for channel in range(self['CGBlock'][dataGroup][channelGroup]['numberOfChannels']):
 
@@ -409,7 +418,13 @@ class info3(dict):
                     signalname = signalname[0]
                     if self.filterChannelNames:
                         signalname = signalname.split('.')[-1]
-                    self['CNBlock'][dataGroup][channelGroup][channel]['signalName'] = signalname
+
+		    if signalname in snames:
+			self['CNBlock'][dataGroup][channelGroup][channel]['signalName'] = signalname + str(channel)
+			print 'WARNING added number to duplicate signal name: ' + self['CNBlock'][dataGroup][channelGroup][channel]['signalName']
+		    else:
+			self['CNBlock'][dataGroup][channelGroup][channel]['signalName'] = signalname
+			snames.add(signalname)
                     channelNameList.append(signalname)
 
         # CLose the file

--- a/mdfreader/mdfinfo3.py
+++ b/mdfreader/mdfinfo3.py
@@ -147,7 +147,7 @@ class info3(dict):
                 # Get pointer to next first Channel block
                 CNpointer = self['CGBlock'][dataGroup][channelGroup]['pointerToFirstCNBlock']
 
-		        snames = set()
+                snames = set()
                 # For each Channel
                 for channel in range(self['CGBlock'][dataGroup][channelGroup]['numberOfChannels']):
 
@@ -180,10 +180,10 @@ class info3(dict):
                     if self.filterChannelNames:
                         signalname = signalname.split('.')[-1]  # filters channels modules
 
-		            if signalname in snames:
+                    if signalname in snames:
 			            self['CNBlock'][dataGroup][channelGroup][channel]['signalName'] = signalname + '_' + str(channel)
 			            print 'WARNING added number to duplicate channel name: ' + self['CNBlock'][dataGroup][channelGroup][channel]['signalName']
-		            else:
+                    else:
 			            self['CNBlock'][dataGroup][channelGroup][channel]['signalName'] = signalname
 			            snames.add(signalname)
                         #self.channelNameList.append( signalname )
@@ -390,7 +390,7 @@ class info3(dict):
                 # Get pointer to next first Channel block
                 CNpointer = self['CGBlock'][dataGroup][channelGroup]['pointerToFirstCNBlock']
 
-		        snames = set()
+                snames = set()
                 # For each Channel
                 for channel in range(self['CGBlock'][dataGroup][channelGroup]['numberOfChannels']):
 
@@ -419,10 +419,10 @@ class info3(dict):
                     if self.filterChannelNames:
                         signalname = signalname.split('.')[-1]
 
-		            if signalname in snames:
+                    if signalname in snames:
 			            self['CNBlock'][dataGroup][channelGroup][channel]['signalName'] = signalname + str(channel)
 			            print 'WARNING added number to duplicate signal name: ' + self['CNBlock'][dataGroup][channelGroup][channel]['signalName']
-		            else:
+                    else:
 			            self['CNBlock'][dataGroup][channelGroup][channel]['signalName'] = signalname
 			            snames.add(signalname)
 

--- a/mdfreader/mdfinfo3.py
+++ b/mdfreader/mdfinfo3.py
@@ -147,7 +147,7 @@ class info3(dict):
                 # Get pointer to next first Channel block
                 CNpointer = self['CGBlock'][dataGroup][channelGroup]['pointerToFirstCNBlock']
 
-		snames = set()
+		        snames = set()
                 # For each Channel
                 for channel in range(self['CGBlock'][dataGroup][channelGroup]['numberOfChannels']):
 
@@ -180,13 +180,13 @@ class info3(dict):
                     if self.filterChannelNames:
                         signalname = signalname.split('.')[-1]  # filters channels modules
 
-		    if signalname in snames:
-			self['CNBlock'][dataGroup][channelGroup][channel]['signalName'] = signalname + '_' + str(channel)
-			print 'WARNING added number to duplicate channel name: ' + self['CNBlock'][dataGroup][channelGroup][channel]['signalName']
-		    else:
-			self['CNBlock'][dataGroup][channelGroup][channel]['signalName'] = signalname
-			snames.add(signalname)
-                    #self.channelNameList.append( signalname )
+		            if signalname in snames:
+			            self['CNBlock'][dataGroup][channelGroup][channel]['signalName'] = signalname + '_' + str(channel)
+			            print 'WARNING added number to duplicate channel name: ' + self['CNBlock'][dataGroup][channelGroup][channel]['signalName']
+		            else:
+			            self['CNBlock'][dataGroup][channelGroup][channel]['signalName'] = signalname
+			            snames.add(signalname)
+                        #self.channelNameList.append( signalname )
 
                     # Read channel description
                     CNTXpointer = self['CNBlock'][dataGroup][channelGroup][channel]['pointerToChannelCommentBlock']
@@ -390,7 +390,7 @@ class info3(dict):
                 # Get pointer to next first Channel block
                 CNpointer = self['CGBlock'][dataGroup][channelGroup]['pointerToFirstCNBlock']
 
-		snames = set()
+		        snames = set()
                 # For each Channel
                 for channel in range(self['CGBlock'][dataGroup][channelGroup]['numberOfChannels']):
 
@@ -419,12 +419,13 @@ class info3(dict):
                     if self.filterChannelNames:
                         signalname = signalname.split('.')[-1]
 
-		    if signalname in snames:
-			self['CNBlock'][dataGroup][channelGroup][channel]['signalName'] = signalname + str(channel)
-			print 'WARNING added number to duplicate signal name: ' + self['CNBlock'][dataGroup][channelGroup][channel]['signalName']
-		    else:
-			self['CNBlock'][dataGroup][channelGroup][channel]['signalName'] = signalname
-			snames.add(signalname)
+		            if signalname in snames:
+			            self['CNBlock'][dataGroup][channelGroup][channel]['signalName'] = signalname + str(channel)
+			            print 'WARNING added number to duplicate signal name: ' + self['CNBlock'][dataGroup][channelGroup][channel]['signalName']
+		            else:
+			            self['CNBlock'][dataGroup][channelGroup][channel]['signalName'] = signalname
+			            snames.add(signalname)
+
                     channelNameList.append(signalname)
 
         # CLose the file

--- a/mdfreader/mdfreader.py
+++ b/mdfreader/mdfreader.py
@@ -165,6 +165,9 @@ class mdfinfo(dict):
             fid = open(self.fileName, 'rb')
         except IOError:
             raise Exception('Can not find file ' + self.fileName)
+        # Check whether file is MDF file -- assumes that every MDF file starts with the letters MDF
+	if not fid.read(3) == 'MDF':
+            raise Exception('file ' + self.fileName + ' is not an MDF file!')
         # read Identifier block
         fid.seek(28)
         MDFVersionNumber = unpack('<H', fid.read(2))


### PR DESCRIPTION
* change in mdfinfo3.py: 
* concerns mf3 files with duplicated signalnames 
* handles these cases by adding _{channel} to the signalname
* (still duplication possible)