### PR TITLE
Bugfix in DATA.read() concerning VSLD channels

### DIFF
--- a/mdfreader/mdf4reader.py
+++ b/mdfreader/mdf4reader.py
@@ -348,7 +348,7 @@ class DATA(dict):
                     rec = self[recordID]['data']  # recarray from data block
                     # determine maximum length of values in VLSD for array dtype
                     # record[cn].maxLengthVLSDRecord=max(diff(rec[convertName(record[cn].name)])-4)
-                    temp = temp.load(record[cn], zip=None, nameList=channelSet, sortedFlag=True)
+                    temp = temp.load(record, zip=None, nameList=channelSet, sortedFlag=True)
                     rec = change_field_name(rec, convertName(record[cn].name), convertName(record[cn].name) + '_offset')
                     rec = append_field(rec, convertName(record[cn].name), temp)
                     self[recordID]['data'] = rec.view(recarray)


### PR DESCRIPTION
While using this great library I found that I couldn't read in an MDF4.1 file and I tracked the problem down to the line I changed. The DATA.load()-method expects a record objects but gets handed over a channel object.

I hope my fix is correct.