### PR TITLE
Allow HL blocks for VLSD data.

### DIFF
--- a/mdfreader/mdf4reader.py
+++ b/mdfreader/mdf4reader.py
@@ -439,7 +439,7 @@ class DATA(dict):
             temp.read(self.fid)
             temps.update(temp)
             self.pointerTodata = temps['hl_dl_first']
-            temps['data'] = self.load(record, info, nameList=nameList, sortedFlag=sortedFlag)
+            temps['data'] = self.load(record, info, nameList=nameList, sortedFlag=sortedFlag, vlsd=vlsd)
         elif temps['id'] in ('##DT', '##RD', b'##DT', b'##RD'):  # normal sorted data block, direct read
             temps['data'] = record.readSortedRecord(self.fid, info, channelSet=nameList)
         elif temps['id'] in ('##SD', b'##SD'):  # VLSD


### PR DESCRIPTION
I have found bug, which cause a crash when using VLSD string signals. This happens if the data is stored under a HL block.

In this case the vlsd parameter was not properly passed to the actual DL/SD loading code. Since without the vlsd parameter set, SD blocks are ignored, this later leads to crash because of missing data.

I think this patch should solve the problem, but I am quite new to this library and my be missing something.