### PR TITLE
 check for native endianness

### DIFF
--- a/mdfreader/mdfreader.py
+++ b/mdfreader/mdfreader.py
@@ -1529,13 +1529,15 @@ class Mdf(Mdf4, Mdf3):
                     temporary_dataframe = pd.DataFrame(index=self.get_channel_data(master_channel_name))
             else:  # no master channel
                 temporary_dataframe = pd.DataFrame()
-            for channel in self.masterChannelList[master_channel_name]:
-                data = self.get_channel_data(channel)
+            channel_dict = {key: None for key in self.masterChannelList[master_channel_name]}
+            for key, value in channel_dict.items():
+                data = self.get_channel_data(key)
                 if data.dtype.byteorder not in ['=', '|']:
                     data = data.byteswap().newbyteorder()
                 if data.ndim == 1 and data.shape[0] == temporary_dataframe.shape[0] \
                         and not data.dtype.char == 'V':
-                    temporary_dataframe[channel] = data
+                    value = data
+            temporary_dataframe = pd.DataFrame(data=channel_dict, index=temporary_dataframe.index)
             return temporary_dataframe
         else:
             warn('Master channel name not in mdf')


### PR DESCRIPTION
If-clause checks, if data is in the native byte order (or not applicable). If this is not the case, the byte order gets changes.

Revoked through the error:
Big-endian buffer not supported on little-endian compiler 

related to issue https://github.com/ratal/mdfreader/issues/210