### PR TITLE
Fixed incorrect class attribute in MdfSkeleton#copy()

### DIFF
--- a/mdfreader/mdf.py
+++ b/mdfreader/mdf.py
@@ -659,7 +659,7 @@ class MdfSkeleton(dict):
         yop.fileMetadata = self.fileMetadata
         yop.MDFVersionNumber = self.MDFVersionNumber
         yop.filterChannelNames = self.filterChannelNames
-        yop.convertTables = self.convert_tables
+        yop.convertTables = self.convertTables
         for channel in self:
             yop[channel] = self[channel]
         return yop


### PR DESCRIPTION
The `copy()` function on the `MdfSkeleton` class referenced an incorrect class attribute - *convert_tables*. Since this attribute uses a camelCase convention, it was corrected to *convertTables*.