### PR TITLE
Make MDF file formula evaluation robust to cases where the 'X' symbol is in lower case

### DIFF
--- a/mdfreader/mdf4reader.py
+++ b/mdfreader/mdf4reader.py
@@ -2343,7 +2343,7 @@ def _formula_conversion(vector, formula):
     except:
         warn('Please install sympy to convert channel ')
     X = symbols('X')
-    expr = lambdify(X, formula, modules='numpy', dummify=False)
+    expr = lambdify(X, formula.upper(), modules='numpy', dummify=False)
     return expr(vector)
 
 


### PR DESCRIPTION
Changed the case of formula strings to always be upper case during evaluation, this makes the formula evaluation robust to cases where the 'X' symbol is lower case (i.e. 'x').